### PR TITLE
fix clone error when specifying hostname/domain

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -547,9 +547,10 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
           identification = RbVmomi::VIM.CustomizationIdentification(
             joinWorkgroup: cust_spec.identity.identification.joinWorkgroup
           )
-          license_file_print_data = RbVmomi::VIM.CustomizationLicenseFilePrintData(
-            autoMode: cust_spec.identity.licenseFilePrintData.autoMode
-          )
+          license_file_print_data = cust_spec.identity.licenseFilePrintData.nil? ? nil :
+            RbVmomi::VIM.CustomizationLicenseFilePrintData(
+              autoMode: cust_spec.identity.licenseFilePrintData.autoMode
+            )
 
           user_data = RbVmomi::VIM.CustomizationUserData(
             fullName: cust_spec.identity.userData.fullName,


### PR DESCRIPTION
licenseFilePrintData is optional and Required only for Windows 2000 Server and Windows Server 2003. 
see http://pubs.vmware.com/vi30/sdk/ReferenceGuide/vim.vm.customization.Sysprep.html#field_detail