### PR TITLE
knife vsphere vm list --only-folders

### DIFF
--- a/lib/chef/knife/vsphere_vm_list.rb
+++ b/lib/chef/knife/vsphere_vm_list.rb
@@ -16,19 +16,28 @@ class Chef::Knife::VsphereVmList < Chef::Knife::BaseVsphereCommand
          short: '-r',
          description: 'Recurse into sub-folders'
 
-  def traverse_folders(folder, is_top = false, recurse = false)
-    vms = find_all_in_folder(folder, RbVmomi::VIM::VirtualMachine).select { |v| v.config && !v.config.template }
-    if vms.any?
-      puts "#{ui.color('Folder', :cyan)}: " + (folder.path[3..-1].map { |x| x[1] }.* '/')
-      vms.each { |v|  print_vm(v) }
-    elsif is_top
-      puts "#{ui.color('No VMs', :cyan)}"
+  option :onlyfolders,
+         long: '--only-folders',
+         description: 'List only the folders found',
+         boolean: false
+
+  def traverse_folders(folder, is_top = false, recurse = false, only_folders = false)
+    if only_folders
+      print_folder(folder)
+    else
+      vms = find_all_in_folder(folder, RbVmomi::VIM::VirtualMachine).select { |v| v.config && !v.config.template }
+      if vms.any?
+        print_folder(folder)
+        vms.each { |v| print_vm(v) }
+      elsif is_top
+        puts "#{ui.color('No VMs', :cyan)}"
+      end
     end
 
     return unless recurse
     folders = find_all_in_folder(folder, RbVmomi::VIM::Folder)
     folders.each do |child|
-      traverse_folders(child, false, recurse)
+      traverse_folders(child, false, recurse, only_folders)
     end
   end
 
@@ -47,11 +56,16 @@ class Chef::Knife::VsphereVmList < Chef::Knife::BaseVsphereCommand
     puts "\t\t#{ui.color('State:', :magenta)} #{state}"
   end
 
+  def print_folder(folder)
+    puts "#{ui.color('Folder', :cyan)}: " + (folder.path[3..-1].map { |x| x[1] }.* '/')
+  end
+
   def run
     vim_connection
     base_folder = find_folder(get_config(:folder))
-    recurse =  get_config(:recursive)
+    only_folders = get_config(:onlyfolders)
+    recurse = only_folders || get_config(:recursive)
     is_top = true
-    traverse_folders(base_folder, is_top, recurse)
+    traverse_folders(base_folder, is_top, recurse, only_folders)
   end
 end


### PR DESCRIPTION
doc states that --only-folders is supported with knife vsphere vm list, but such a switch was missing from the implementation.  this is an implementation of what I believe the spirit of that would be

Sample output:

list with no args:
```
Folder: 
	VM Name: Machine 1
		IP: 
		RAM: 4096
		State: off
	VM Name: Machine 2
		IP: 10.28.64.112
		RAM: 6144
		State: on
	VM Name: Machine 3
		IP: 
		RAM: 4096
		State: off
	VM Name: Machine 4
		IP: 
		RAM: 8192
		State: off
```

list with -r:
```
Folder: 
	VM Name: Machine 1
		IP: 
		RAM: 4096
		State: off
	VM Name: Machine 2
		IP: 10.28.64.112
		RAM: 6144
		State: on
	VM Name: Machine 3
		IP: 
		RAM: 4096
		State: off
	VM Name: Machine 4
		IP: 
		RAM: 8192
		State: off
Folder: SubFolder 1
	VM Name: Machine 1
		IP: 10.28.64.198
		RAM: 1536
		State: on
```

list with --only-folders:
```
Folder: 
```

list with --only-folders -r:
```
Folder: 
Folder: SubFolder 1
```